### PR TITLE
Remove Cython from install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     zip_safe=False,
     python_requires='>=3.7',
     package_dir={'primecountpy': 'primecountpy'},
-    install_requires=["Cython", "cysignals"],
+    install_requires=["cysignals"],
     package_data={"primecountpy": ["*.pxd"],
           "docs": ["*"], "docs.source": ["*"], "docs.source.modules": ["*"],
           },


### PR DESCRIPTION
It's only a build dependency and not a runtime dependency.  This fixes Debian bug [1058000](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1058000).