### PR TITLE
use license syntax in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,10 @@ dependencies = [
     "cysignals",
 ]
 requires-python = ">=3.7"
-license = {text = "GPLv3"}
+license = "GPL-3.0-or-later"
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Mathematics",
 ]


### PR DESCRIPTION
to avoid a deprecation warning