### PR TITLE
Build wheels for Windows

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -33,6 +33,8 @@ jobs:
         os:
           - ubuntu-latest
           - ubuntu-24.04-arm
+          - windows-latest
+          - windows-11-arm
           - macos-15-intel
           - macos-latest
     steps:

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -34,7 +34,7 @@ jobs:
           - ubuntu-latest
           - ubuntu-24.04-arm
           - windows-latest
-          - windows-11-arm
+          #- windows-11-arm: https://github.com/dimpase/primecountpy/issues/30
           - macos-15-intel
           - macos-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,13 +43,15 @@ dev = [
 ]
 
 [project.optional-dependencies]
-doc = [
-    "sphinx",
-    "myst_parser",
-]
+doc = ["sphinx", "myst_parser"]
 
 [tool.meson-python.args]
 # Don't install subprojects and ensure that targets are built as static
 # as per https://mesonbuild.com/meson-python/how-to-guides/shared-libraries.html#static-library-from-subproject
 setup = ['--default-library=static']
 install = ['--skip-subprojects']
+
+[tool.cibuildwheel]
+#test-groups = ["dev"]
+#test-command = "pytest ."
+build-frontend = "build[uv]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ setup = ['--default-library=static']
 install = ['--skip-subprojects']
 
 [tool.cibuildwheel]
+skip = ["*-win32"]
 #test-groups = ["dev"]
 #test-command = "pytest ."
 build-frontend = "build[uv]"


### PR DESCRIPTION
The Windows wheels failed to build due to 
> Need python for x86_64, but found x86
https://github.com/dimpase/primecountpy/actions/runs/20509947760/job/58929733667?pr=26#step:4:353

~Let's see if using the uv-wheel-building frontend works.~ So we simply skip building 32-bit Win wheels.